### PR TITLE
Use explicit 0 instead of AsyncoverflowPolicy::block_retry to avoid gcc 5.4 link error

### DIFF
--- a/src/pyspdlog.cpp
+++ b/src/pyspdlog.cpp
@@ -403,7 +403,7 @@ PYBIND11_MODULE(spdlog, m) {
 
     m.def("set_async_mode", set_async_mode, 
             py::arg("queue_size") = 1 << 16,
-            py::arg("async_overflow_policy") = AsyncOverflowPolicy::block_retry,
+            py::arg("async_overflow_policy") = 0,    // 0 equals AsyncOverflowPolicy::block_retry - using block_retry results in gcc 5.4 compiler error
             py::arg("worker_warmup_cb") = nullptr,
             py::arg("flush_interval_ms") = 10,
             py::arg("worker_teardown_cb") = nullptr


### PR DESCRIPTION
Fix gcc 5.4 link error